### PR TITLE
Enable aliases when parsing erb yml files

### DIFF
--- a/lib/anyway/config.rb
+++ b/lib/anyway/config.rb
@@ -112,7 +112,7 @@ module Anyway # :nodoc:
     def parse_yml(path)
       require 'yaml'
       if defined?(ERB)
-        YAML.safe_load(ERB.new(File.read(path)).result)
+        YAML.safe_load(ERB.new(File.read(path)).result, [], [], true)
       else
         YAML.load_file(path)
       end


### PR DESCRIPTION
Otherwise it is raising error `Unknown alias: default (Psych::BadAlias)`
https://ruby-doc.org/stdlib-2.1.0/libdoc/psych/rdoc/Psych.html#method-c-safe_load