### PR TITLE
feature: allow to pass raw hash as defaults settings

### DIFF
--- a/anyway_config.gemspec
+++ b/anyway_config.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.summary     = "Configuration DSL for Ruby libraries and applications"
   s.description = %{
     Configuration DSL for Ruby libraries and applications.
-
     Allows you to easily follow the twelve-factor application principles (https://12factor.net/config).
   }
 
@@ -24,6 +23,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.2'
 
   s.add_development_dependency "rspec", "~> 3.5"
-  s.add_development_dependency "rubocop", "~> 0.49"
+  s.add_development_dependency "rubocop", "~> 0.52"
   s.add_development_dependency "simplecov", ">= 0.3.8"
 end

--- a/lib/anyway/rails/config.rb
+++ b/lib/anyway/rails/config.rb
@@ -18,9 +18,7 @@ module Anyway
 
     def load_from_file(config)
       config_path = Rails.root.join("config", "#{@config_name}.yml")
-      if File.file? config_path
-        config.deep_merge!(parse_yml(config_path)[Rails.env] || {})
-      end
+      config.deep_merge!(parse_yml(config_path)[Rails.env] || {}) if File.file? config_path
       config
     end
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -54,6 +54,11 @@ describe Anyway::Config do
         expect(conf.host).to eq "test.host"
       end
 
+      it "sets overrides after loading YAML" do
+        config = CoolConfig.new(overrides: { host: 'overrided.host' })
+        expect(config.host).to eq "overrided.host"
+      end
+
       if Rails.application.respond_to?(:secrets)
         it "load config from secrets" do
           expect(conf.user[:name]).to eq "test"
@@ -78,6 +83,17 @@ describe Anyway::Config do
       it "handle ENV in YML thru ERB" do
         ENV['ANYWAY_SECRET_PASSWORD'] = 'my_pass'
         expect(conf.user[:password]).to eq 'my_pass'
+      end
+
+      it "overrides loaded value by explicit" do
+        ENV['ANYWAY_SECRET_PASSWORD'] = 'my_pass'
+
+        config = CoolConfig.new(
+          overrides: {
+            user: { password: 'explicit_password' }
+          }
+        )
+        expect(config.user[:password]).to eq "explicit_password"
       end
     end
 
@@ -118,9 +134,7 @@ describe Anyway::Config do
       data = Anyway::Config.for(:my_app)
       expect(data[:test]).to eq 1
       expect(data[:name]).to eq 'my_app'
-      if Rails.application.respond_to?(:secrets)
-        expect(data[:secret]).to eq 'my_secret'
-      end
+      expect(data[:secret]).to eq 'my_secret' if Rails.application.respond_to?(:secrets)
     end
   end
 
@@ -130,6 +144,14 @@ describe Anyway::Config do
     it "works" do
       expect(conf.meta).to be_nil
       expect(conf.data).to be_nil
+    end
+  end
+
+  context "config with initial hash values" do
+    let(:conf) { SmallConfig.new(overrides: { 'meta': 'dummy' }) }
+
+    it "works" do
+      expect(conf.meta).to eq 'dummy'
     end
   end
 


### PR DESCRIPTION
Hi!

Want to support somethings like this to allow to pass options, which will be applied after defaults for new instance of config
Usage looks like this:
```ruby
Sniffer::Config.new(
  enabled: true,
  storage: {capacity: 500}
)
```

Will be used [here](https://github.com/aderyabin/sniffer/pull/35/files#diff-e8dd54a3960ba73344f6ec9bf5ea2ee2R14) in https://github.com/aderyabin/sniffer/pull/35