### PR TITLE
Do not print deprecation message when env_prefix is explicitly set

### DIFF
--- a/lib/anyway/config.rb
+++ b/lib/anyway/config.rb
@@ -78,7 +78,7 @@ module Anyway # :nodoc:
 
       raise ArgumentError, "Config name is missing" unless @config_name
 
-      if @config_name.to_s.include?('_') && @env_prefix.nil?
+      if @config_name.to_s.include?('_') && self.class.env_prefix.nil?
         warn "[Deprecated] As your config_name is #{@config_name}, " \
              "the prefix `#{@config_name.to_s.delete('_').upcase}` " \
              "will be used to parse env variables. " \

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -100,6 +100,35 @@ describe Anyway::Config do
         end
       end
 
+      context "when config_name contains underscores" do
+        let(:conf) do
+          klass = CoolConfig.dup
+          klass.class_eval do
+            config_name :cool_thing
+          end
+          klass.new
+        end
+
+        it "warns user about deprecated behaviour" do
+          expect { conf }.to print_warning
+        end
+
+        context "when env_name is set" do
+          let(:conf) do
+            klass = CoolConfig.dup
+            klass.class_eval do
+              config_name :cool_thing
+              env_prefix  :cool_thing
+            end
+            klass.new
+          end
+
+          it "doesn't print deprecation warning" do
+            expect { conf }.not_to print_warning
+          end
+        end
+      end
+
       it "handle ENV in YML thru ERB" do
         ENV['ANYWAY_SECRET_PASSWORD'] = 'my_pass'
         expect(conf.user[:password]).to eq 'my_pass'

--- a/spec/support/print_warning_matcher.rb
+++ b/spec/support/print_warning_matcher.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :print_warning do |message|
+  def supports_block_expectations?
+    true
+  end
+
+  match do |block|
+    stderr = fake_stderr(&block)
+    message ? stderr.include?(message) : !stderr.empty?
+  end
+
+  description do
+    "write #{message && "\"#{message}\"" || 'anything'} to standard error"
+  end
+
+  failure_message do
+    "expected to #{description}"
+  end
+
+  failure_message_when_negated do
+    "expected not to #{description}"
+  end
+
+  # Fake STDERR and return a string written to it.
+  def fake_stderr
+    original_stderr = $stderr
+    $stderr = StringIO.new
+    yield
+    $stderr.string
+  ensure
+    $stderr = original_stderr
+  end
+end


### PR DESCRIPTION
Follow up for #12

Now (on 1.3.0) even if I have set `env_prefix` in the configuration it still prints annoying deprecation message.

Let's fix it.