### PR TITLE
Fix deprecation notices about converting Hash into keyword arguments

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5.x", "2.6.x"]
+        ruby: ["2.5.x", "2.6.x", "2.7.x"]
         gemfile: [
           "gemfiles/railsmaster.gemfile",
           "gemfiles/rails6.gemfile",

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,7 +27,7 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: no_comma
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   EnforcedStyle: with_first_parameter
 
 Lint/Void:

--- a/lib/anyway/config.rb
+++ b/lib/anyway/config.rb
@@ -170,8 +170,8 @@ module Anyway # :nodoc:
     end
 
     def each_source(options)
-      yield load_from_file(options)
-      yield load_from_env(options)
+      yield load_from_file(**options)
+      yield load_from_env(**options)
     end
 
     def load_from_file(name:, env_prefix:, config_path:, **_options)

--- a/lib/anyway/rails/config.rb
+++ b/lib/anyway/rails/config.rb
@@ -27,10 +27,10 @@ module Anyway
       end
 
       def each_source(options)
-        yield load_from_file(options)
-        yield load_from_secrets(options)
-        yield load_from_credentials(options)
-        yield load_from_env(options)
+        yield load_from_file(**options)
+        yield load_from_secrets(**options)
+        yield load_from_credentials(**options)
+        yield load_from_env(**options)
       end
 
       def load_from_file(name:, config_path:, env_prefix:, **_options)


### PR DESCRIPTION
Change-Id: I05162bc511252304a89b80b78a0ad2ce264e4d47

<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

## What is the purpose of this pull request?

Fixes #48

Remove warnings about using the last argument as keyword arguments.

## What changes did you make? (overview)

Convert hash to keyword arguments in several method calls.

## Is there anything you'd like reviewers to focus on?

## Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation
