### PR TITLE
Fix double yielding in tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Fix double `yield` in tracing for ENV loader. ([@Envek][])
+
 ## 2.0.0.rc1 (2020-03-31)
 
 - Add predicate methods for attributes with boolean defaults. ([@palkan][])
@@ -348,3 +350,4 @@ Now works on JRuby 9.1+.
 [@dsalahutdinov]: https://github.com/dsalahutdinov
 [@charlie-wasp]: https://github.com/charlie-wasp
 [@jastkand]: https://github.com/jastkand
+[@Envek]: https://github.com/Envek

--- a/lib/anyway/tracing.rb
+++ b/lib/anyway/tracing.rb
@@ -183,7 +183,7 @@ module Anyway
       if val.is_a?(Hash)
         Tracing.current_trace.merge_values(val, **source)
       else
-        Tracing.current_trace.record_value(yield, *path, **source)
+        Tracing.current_trace.record_value(val, *path, **source)
       end
       val
     end


### PR DESCRIPTION
## What is the purpose of this pull request?

Fix double yield to `data.bury` in environment variable loader.

## What changes did you make? (overview)

Replaced second `yield` that retrieves already retrieved value again with that value. That is it. 

## Checklist

- [x] ~I've added tests for this change~ Not needed
- [x] I've added a Changelog entry
- [x] ~I've updated a documentation~ Not needed
