### PR TITLE
Fix check of RSpec.configure presence.

### DIFF
--- a/lib/anyway/testing.rb
+++ b/lib/anyway/testing.rb
@@ -2,7 +2,7 @@
 
 require "anyway/testing/helpers"
 
-if defined?(RSpec) && defined?(RSpec.configure)
+if defined?(RSpec::Core)
   RSpec.configure do |config|
     config.include(
       Anyway::Testing::Helpers,

--- a/lib/anyway/testing.rb
+++ b/lib/anyway/testing.rb
@@ -2,7 +2,7 @@
 
 require "anyway/testing/helpers"
 
-if defined?(RSpec)
+if defined?(RSpec) && defined?(RSpec.configure)
   RSpec.configure do |config|
     config.include(
       Anyway::Testing::Helpers,

--- a/lib/anyway/version.rb
+++ b/lib/anyway/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Anyway # :nodoc:
-  VERSION = "2.0.3"
+  VERSION = "2.0.2"
 end

--- a/lib/anyway/version.rb
+++ b/lib/anyway/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Anyway # :nodoc:
-  VERSION = "2.0.2"
+  VERSION = "2.0.3"
 end


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

## What is the purpose of this pull request?

Fix issue when RSpec.configure isn't defined yet, but the RSpec module already exists.
<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

## What changes did you make? (overview)

Just add an additional check that RSpec.configuration is defined.

## Is there anything you'd like reviewers to focus on?

## Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation
