### PR TITLE
load whole config when no environmental keys present in Rails config YML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master
 
+- Allow to skip environment keys completely (e.g., `development:`, `test:`) in a config YML when used with Rails. In that case same config is loaded in all known environments (same mechanism as for non-Rails applications)
+- Add the `known_environments` property to Anyway::Settings under Rails. Use `config.anyway_config.known_environments << "staging"` to make the gem aware of custom environments. ([@progapandist][])
+
 - Make it possible to specify default YML configs directory. ([@palkan][])
 
 For example:
@@ -376,4 +379,5 @@ No we're dependency-free!
 [@dsalahutdinov]: https://github.com/dsalahutdinov
 [@charlie-wasp]: https://github.com/charlie-wasp
 [@jastkand]: https://github.com/jastkand
-[@Envek]: https://github.com/Envek
+[@envek]: https://github.com/Envek
+[@progapandist]: https://github.com/progapandist

--- a/README.md
+++ b/README.md
@@ -261,19 +261,19 @@ config = Anyway::Config.for(:my_app, config_path: "my_config.yml", env_prefix: "
 
 This feature is similar to `Rails.application.config_for` but more powerful:
 
-| Feature | Rails | Anyway Config |
-| ------------- |-------------:| -----:|
-| Load data from `config/app.yml` | ✅ | ✅ |
-| Load data from `secrets` | ❌ | ✅ |
-| Load data from `credentials` | ❌ | ✅ |
-| Load data from environment | ❌ | ✅ |
-| Load data from [custom sources](#data-loaders) | ❌ | ✅ |
-| Local config files | ❌ | ✅ |
-| [Source tracing](#tracing) | ❌ | ✅ |
-| Return Hash with indifferent access | ❌ | ✅ |
-| Support ERB\* within `config/app.yml` | ✅ | ✅ |
-| Raise if file doesn't exist | ✅ | ❌ |
-| Works without Rails | 😀 | ✅ |
+| Feature                                        | Rails | Anyway Config |
+| ---------------------------------------------- | ----: | ------------: |
+| Load data from `config/app.yml`                |    ✅ |            ✅ |
+| Load data from `secrets`                       |    ❌ |            ✅ |
+| Load data from `credentials`                   |    ❌ |            ✅ |
+| Load data from environment                     |    ❌ |            ✅ |
+| Load data from [custom sources](#data-loaders) |    ❌ |            ✅ |
+| Local config files                             |    ❌ |            ✅ |
+| [Source tracing](#tracing)                     |    ❌ |            ✅ |
+| Return Hash with indifferent access            |    ❌ |            ✅ |
+| Support ERB\* within `config/app.yml`          |    ✅ |            ✅ |
+| Raise if file doesn't exist                    |    ✅ |            ❌ |
+| Works without Rails                            |    😀 |            ✅ |
 
 \* Make sure that ERB is loaded
 
@@ -329,7 +329,7 @@ and then use [Rails generators](#generators) to make your application Anyway Con
 
 Your config is filled up with values from the following sources (ordered by priority from low to high):
 
-1) **YAML configuration files**: `RAILS_ROOT/config/my_cool_gem.yml`.
+1. **YAML configuration files**: `RAILS_ROOT/config/my_cool_gem.yml`.
 
 Recognizes Rails environment, supports `ERB`:
 
@@ -341,6 +341,29 @@ test:
 development:
   host: localhost
   port: 3000
+```
+
+If the YML does not have keys that are one of the "known" Rails environments (development, production, test)—the same configuration will be available in all environments, similar to non-Rails behavior:
+
+```yml
+host: localhost
+port: 3002
+# These values will be active in all environments
+```
+
+To extend the list of known environments, use the setting in the relevant part of your Rails code:
+
+```ruby
+Rails.application.config.anyway_config.known_environments << "staging"
+```
+
+If your YML defines at least a single "environmental" top-level, you _have_ to separate all your settings per-environment. You can't mix and match:
+
+```yml
+staging:
+  host: localhost # This value will be loaded when Rails.env.staging? is true
+
+port: 3002 # This value will not be loaded at all
 ```
 
 You can specify the lookup path for YAML files in one of the following ways:
@@ -360,7 +383,7 @@ config.anyway_config.default_config_path = ->(name) { Rails.root.join("data", "c
 
 - By overriding a specific config YML file path via the `<NAME>_CONF` env variable, e.g., `MYCOOLGEM_CONF=path/to/cool.yml`
 
-2) **Rails secrets**: `Rails.application.secrets.my_cool_gem` (if `secrets.yml` present).
+2. **Rails secrets**: `Rails.application.secrets.my_cool_gem` (if `secrets.yml` present).
 
 ```yml
 # config/secrets.yml
@@ -369,7 +392,7 @@ development:
     port: 4444
 ```
 
-3) **Rails credentials**: `Rails.application.credentials.my_cool_gem` (if supported):
+3. **Rails credentials**: `Rails.application.credentials.my_cool_gem` (if supported):
 
 ```yml
 my_cool_gem:
@@ -378,7 +401,7 @@ my_cool_gem:
 
 **NOTE:** You can backport Rails 6 per-environment credentials to Rails 5.2 app using [this patch](https://gist.github.com/palkan/e27e4885535ff25753aefce45378e0cb).
 
-4) **Environment variables**: `ENV['MYCOOLGEM_*']`.
+4. **Environment variables**: `ENV['MYCOOLGEM_*']`.
 
 See [environment variables](#environment-variables).
 
@@ -461,7 +484,7 @@ Alternatively, you can call `rails g anyway:app_config name param1 param2 ...`.
 
 The default data loading mechanism for non-Rails applications is the following (ordered by priority from low to high):
 
-1) **YAML configuration files**: `./config/<config-name>.yml`.
+1. **YAML configuration files**: `./config/<config-name>.yml`.
 
 In pure Ruby apps, we do not know about _environments_ (`test`, `development`, `production`, etc.); thus, we assume that the YAML contains values for a single environment:
 
@@ -488,7 +511,7 @@ Anyway::Settings.default_config_path = ->(name) { Rails.root.join("data", "confi
 
 - By overriding a specific config YML file path via the `<NAME>_CONF` env variable, e.g., `MYCOOLGEM_CONF=path/to/cool.yml`
 
-2) **Environment variables**: `ENV['MYCOOLGEM_*']`.
+2. **Environment variables**: `ENV['MYCOOLGEM_*']`.
 
 See [environment variables](#environment-variables).
 
@@ -505,9 +528,9 @@ Environment variables are automatically type cast:
 - `"nil"` and `"null"` to `nil` (do you really need it?);
 - `"123"` to 123 and `"3.14"` to 3.14.
 
-*Anyway Config* supports nested (_hashed_) env variables—just separate keys with double-underscore.
+_Anyway Config_ supports nested (_hashed_) env variables—just separate keys with double-underscore.
 
-For example, "MYCOOLGEM_OPTIONS__VERBOSE" is parsed as `config.options["verbose"]`.
+For example, "MYCOOLGEM_OPTIONS\_\_VERBOSE" is parsed as `config.options["verbose"]`.
 
 Array values are also supported:
 

--- a/README.md
+++ b/README.md
@@ -261,19 +261,19 @@ config = Anyway::Config.for(:my_app, config_path: "my_config.yml", env_prefix: "
 
 This feature is similar to `Rails.application.config_for` but more powerful:
 
-| Feature                                        | Rails | Anyway Config |
-| ---------------------------------------------- | ----: | ------------: |
-| Load data from `config/app.yml`                |    ✅ |            ✅ |
-| Load data from `secrets`                       |    ❌ |            ✅ |
-| Load data from `credentials`                   |    ❌ |            ✅ |
-| Load data from environment                     |    ❌ |            ✅ |
-| Load data from [custom sources](#data-loaders) |    ❌ |            ✅ |
-| Local config files                             |    ❌ |            ✅ |
-| [Source tracing](#tracing)                     |    ❌ |            ✅ |
-| Return Hash with indifferent access            |    ❌ |            ✅ |
-| Support ERB\* within `config/app.yml`          |    ✅ |            ✅ |
-| Raise if file doesn't exist                    |    ✅ |            ❌ |
-| Works without Rails                            |    😀 |            ✅ |
+| Feature | Rails | Anyway Config |
+| ------------- |-------------:| -----:|
+| Load data from `config/app.yml` | ✅ | ✅ |
+| Load data from `secrets` | ❌ | ✅ |
+| Load data from `credentials` | ❌ | ✅ |
+| Load data from environment | ❌ | ✅ |
+| Load data from [custom sources](#data-loaders) | ❌ | ✅ |
+| Local config files | ❌ | ✅ |
+| [Source tracing](#tracing) | ❌ | ✅ |
+| Return Hash with indifferent access | ❌ | ✅ |
+| Support ERB\* within `config/app.yml` | ✅ | ✅ |
+| Raise if file doesn't exist | ✅ | ❌ |
+| Works without Rails | 😀 | ✅ |
 
 \* Make sure that ERB is loaded
 
@@ -329,7 +329,7 @@ and then use [Rails generators](#generators) to make your application Anyway Con
 
 Your config is filled up with values from the following sources (ordered by priority from low to high):
 
-1. **YAML configuration files**: `RAILS_ROOT/config/my_cool_gem.yml`.
+1) **YAML configuration files**: `RAILS_ROOT/config/my_cool_gem.yml`.
 
 Recognizes Rails environment, supports `ERB`:
 
@@ -383,7 +383,7 @@ config.anyway_config.default_config_path = ->(name) { Rails.root.join("data", "c
 
 - By overriding a specific config YML file path via the `<NAME>_CONF` env variable, e.g., `MYCOOLGEM_CONF=path/to/cool.yml`
 
-2. **Rails secrets**: `Rails.application.secrets.my_cool_gem` (if `secrets.yml` present).
+2) **Rails secrets**: `Rails.application.secrets.my_cool_gem` (if `secrets.yml` present).
 
 ```yml
 # config/secrets.yml
@@ -392,7 +392,7 @@ development:
     port: 4444
 ```
 
-3. **Rails credentials**: `Rails.application.credentials.my_cool_gem` (if supported):
+3) **Rails credentials**: `Rails.application.credentials.my_cool_gem` (if supported):
 
 ```yml
 my_cool_gem:
@@ -401,7 +401,7 @@ my_cool_gem:
 
 **NOTE:** You can backport Rails 6 per-environment credentials to Rails 5.2 app using [this patch](https://gist.github.com/palkan/e27e4885535ff25753aefce45378e0cb).
 
-4. **Environment variables**: `ENV['MYCOOLGEM_*']`.
+4) **Environment variables**: `ENV['MYCOOLGEM_*']`.
 
 See [environment variables](#environment-variables).
 
@@ -484,7 +484,7 @@ Alternatively, you can call `rails g anyway:app_config name param1 param2 ...`.
 
 The default data loading mechanism for non-Rails applications is the following (ordered by priority from low to high):
 
-1. **YAML configuration files**: `./config/<config-name>.yml`.
+1) **YAML configuration files**: `./config/<config-name>.yml`.
 
 In pure Ruby apps, we do not know about _environments_ (`test`, `development`, `production`, etc.); thus, we assume that the YAML contains values for a single environment:
 
@@ -511,7 +511,7 @@ Anyway::Settings.default_config_path = ->(name) { Rails.root.join("data", "confi
 
 - By overriding a specific config YML file path via the `<NAME>_CONF` env variable, e.g., `MYCOOLGEM_CONF=path/to/cool.yml`
 
-2. **Environment variables**: `ENV['MYCOOLGEM_*']`.
+2) **Environment variables**: `ENV['MYCOOLGEM_*']`.
 
 See [environment variables](#environment-variables).
 
@@ -528,9 +528,9 @@ Environment variables are automatically type cast:
 - `"nil"` and `"null"` to `nil` (do you really need it?);
 - `"123"` to 123 and `"3.14"` to 3.14.
 
-_Anyway Config_ supports nested (_hashed_) env variables—just separate keys with double-underscore.
+*Anyway Config* supports nested (_hashed_) env variables—just separate keys with double-underscore.
 
-For example, "MYCOOLGEM_OPTIONS\_\_VERBOSE" is parsed as `config.options["verbose"]`.
+For example, "MYCOOLGEM_OPTIONS__VERBOSE" is parsed as `config.options["verbose"]`.
 
 Array values are also supported:
 

--- a/lib/anyway/rails/loaders/yaml.rb
+++ b/lib/anyway/rails/loaders/yaml.rb
@@ -16,7 +16,6 @@ module Anyway
         def environmental?(parsed_yml)
           # likely
           return true if parsed_yml.key?(::Rails.env)
-          
           # less likely
           ::Rails.application.config.anyway_config.known_environments.any? { parsed_yml.key?(_1) }
         end

--- a/lib/anyway/rails/loaders/yaml.rb
+++ b/lib/anyway/rails/loaders/yaml.rb
@@ -14,10 +14,11 @@ module Anyway
         private
 
         def environmental?(parsed_yml)
-          parsed_yml.keys.any? do |key|
-            envs = ::Rails.application.config.anyway_config.known_environments.dup
-            envs.concat([::Rails.env]).include?(key)
-          end
+          # likely
+          return true if parsed_yml.key?(::Rails.env)
+          
+          # less likely
+          ::Rails.application.config.anyway_config.known_environments.any? { parsed_yml.key?(_1) }
         end
 
         def relative_config_path(path)

--- a/lib/anyway/rails/loaders/yaml.rb
+++ b/lib/anyway/rails/loaders/yaml.rb
@@ -5,10 +5,17 @@ module Anyway
     module Loaders
       class YAML < Anyway::Loaders::YAML
         def load_base_yml(*)
+          parsed_yml = super
+          return parsed_yml unless environmental?(parsed_yml)
+
           super[::Rails.env] || {}
         end
 
         private
+
+        def environmental?(parsed_yml)
+          parsed_yml.keys.any? { |key| ["test", "development", "production", ::Rails.env].include?(key) }
+        end
 
         def relative_config_path(path)
           Pathname.new(path).relative_path_from(::Rails.root)

--- a/lib/anyway/rails/loaders/yaml.rb
+++ b/lib/anyway/rails/loaders/yaml.rb
@@ -14,7 +14,10 @@ module Anyway
         private
 
         def environmental?(parsed_yml)
-          parsed_yml.keys.any? { |key| ["test", "development", "production", ::Rails.env].include?(key) }
+          parsed_yml.keys.any? do |key|
+            envs = ::Rails.application.config.anyway_config.known_environments.dup
+            envs.concat([::Rails.env]).include?(key)
+          end
         end
 
         def relative_config_path(path)

--- a/lib/anyway/rails/settings.rb
+++ b/lib/anyway/rails/settings.rb
@@ -11,6 +11,7 @@ module Anyway
   class Settings
     class << self
       attr_reader :autoload_static_config_path, :autoloader
+      attr_accessor :known_environments
 
       if defined?(::Zeitwerk)
         def autoload_static_config_path=(val)
@@ -56,5 +57,6 @@ module Anyway
     end
 
     self.default_config_path = ->(name) { ::Rails.root.join("config", "#{name}.yml") }
+    self.known_environments = %w[test development production]
   end
 end

--- a/spec/dummy/config/cool_no_environments.yml
+++ b/spec/dummy/config/cool_no_environments.yml
@@ -1,0 +1,4 @@
+host: "test.host"
+user:
+  name: "root"
+  password: <%= ENV['ANY_SECRET_PASSWORD'] || "root" %>

--- a/spec/dummy/config/cool_staging_environment.yml
+++ b/spec/dummy/config/cool_staging_environment.yml
@@ -1,0 +1,5 @@
+staging:
+  host: "test.host"
+  user:
+    name: "root"
+    password: <%= ENV['ANY_SECRET_PASSWORD'] || "root" %>

--- a/spec/dummy/config/cool_unmatched_environment.yml
+++ b/spec/dummy/config/cool_unmatched_environment.yml
@@ -1,0 +1,5 @@
+production:
+  host: "test.host"
+  user:
+    name: "root"
+    password: <%= ENV['ANY_SECRET_PASSWORD'] || "root" %>

--- a/spec/rails/loaders/yaml_spec.rb
+++ b/spec/rails/loaders/yaml_spec.rb
@@ -21,6 +21,22 @@ describe "Anyway::Rails::Loaders::YAML", :rails do
     )
   end
 
+  context "when no top environmental keys present" do
+    let(:options) { {config_path: Rails.root.join("config/cool_no_environments.yml"), some_other: "value"} }
+
+    it "still loads settings" do
+      expect(subject).to eq(
+        {
+          "host" => "test.host",
+          "user" => {
+            "name" => "root",
+            "password" => "root"
+          }
+        }
+      )
+    end
+  end
+
   context "when local is enabled" do
     let(:options) { {config_path: path, local: true, some_other: "value"} }
 

--- a/spec/rails/loaders/yaml_spec.rb
+++ b/spec/rails/loaders/yaml_spec.rb
@@ -21,10 +21,15 @@ describe "Anyway::Rails::Loaders::YAML", :rails do
     )
   end
 
-  context "when no top environmental keys present" do
-    let(:options) { {config_path: Rails.root.join("config/cool_no_environments.yml"), some_other: "value"} }
+  context "when the environmental key doesn't match the current environment" do
+    let(:options) { {config_path: Rails.root.join("config/cool_unmatched_environment.yml"), some_other: "value"} }
 
-    it "still loads settings" do
+    it "doesn't load any settings for the current environment" do
+      expect(subject).to be_empty
+    end
+
+    it "loads correct settings if the environment is switched" do
+      Rails.env = "production"
       expect(subject).to eq(
         {
           "host" => "test.host",
@@ -34,6 +39,64 @@ describe "Anyway::Rails::Loaders::YAML", :rails do
           }
         }
       )
+      Rails.env = "test"
+    end
+  end
+
+  context "when no top environmental keys present" do
+    let(:options) { {config_path: Rails.root.join("config/cool_no_environments.yml"), some_other: "value"} }
+
+    it "loads settings for all environments" do
+      expect(subject).to eq(
+        {
+          "host" => "test.host",
+          "user" => {
+            "name" => "root",
+            "password" => "root"
+          }
+        }
+      )
+      Rails.env = "production"
+      expect(subject).to eq(
+        {
+          "host" => "test.host",
+          "user" => {
+            "name" => "root",
+            "password" => "root"
+          }
+        }
+      )
+      Rails.env = "test"
+    end
+  end
+
+  context "when new known_environment is added to config and used as top-level key" do
+    let(:options) { {config_path: Rails.root.join("config/cool_staging_environment.yml"), some_other: "value"} }
+    let(:config) { Rails.application.config.anyway_config }
+
+    it "does not leak settings into other environments" do
+      config.known_environments << "staging"
+      expect(subject).to be_empty
+      Rails.env = "development"
+      expect(subject).to be_empty
+      Rails.env = "production"
+      expect(subject).to be_empty
+      Rails.env = "test"
+    end
+
+    it "picks up settings for new environment" do
+      config.known_environments << "staging"
+      Rails.env = "staging"
+      expect(subject).to eq(
+        {
+          "host" => "test.host",
+          "user" => {
+            "name" => "root",
+            "password" => "root"
+          }
+        }
+      )
+      Rails.env = "test"
     end
   end
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Load configuration in Rails when no "environmental" top keys are present in the `config/my_gem.yml`

## What changes did you make? (overview)

Сheck if the YML contains top-level keys that correspond to Rails environments

## Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation
