### PR TITLE
Relax README gem version constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Or adding to your project:
 
 ```ruby
 # Gemfile
-gem "anyway_config", "~> 2.0.0"
+gem "anyway_config", "~> 2.0"
 ```
 
 ### Supported Ruby versions


### PR DESCRIPTION
The version constraint in the installation section of the README prevents the
most recent version of the gem from being pulled down as you will end up with
2.0.6 instead of 2.1.0. Relaxing the constraint a bit fixes this.