### PR TITLE
Set fallback for empty YAML config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Do not dup modules/classes passed as configuration values. ([@palkan][])
 
+- Handle loading empty YAML config files. ([@micahlee][])
+
 ## 2.1.0 (2020-12-29)
 
 - Drop deprecated `attr_config` instance variables support.

--- a/lib/anyway/loaders/yaml.rb
+++ b/lib/anyway/loaders/yaml.rb
@@ -25,10 +25,14 @@ module Anyway
       def parse_yml(path)
         return {} unless File.file?(path)
         require "yaml" unless defined?(::YAML)
+
+        # By default, YAML load will return `false` when the yaml document is
+        # empty. When this occurs, we return an empty hash instead, to match
+        # the interface when no config file is present.
         if defined?(ERB)
-          ::YAML.load(ERB.new(File.read(path)).result) # rubocop:disable Security/YAMLLoad
+          ::YAML.load(ERB.new(File.read(path)).result) || {} # rubocop:disable Security/YAMLLoad
         else
-          ::YAML.load_file(path)
+          ::YAML.load_file(path) || {}
         end
       end
 

--- a/spec/loaders/yaml_spec.rb
+++ b/spec/loaders/yaml_spec.rb
@@ -60,4 +60,12 @@ describe Anyway::Loaders::YAML do
       expect(subject).to eq({})
     end
   end
+
+  context "when file is empty" do
+    let(:options) { {config_path: File.join(__dir__, "../config/empty.yml")} }
+
+    it "returns empty hash" do
+      expect(subject).to eq({})
+    end
+  end
 end


### PR DESCRIPTION
## What is the purpose of this pull request?

This PR addresses a bug when attempting to load an empty config file (or a file that is all comments). Currently, this results in an error:

```
undefined method `key?' for false:FalseClass
```

I didn't first file a bug issue for this, but I can if you prefer.
<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

Thanks!!

## What changes did you make? (overview)

By default, loading an empty YAML file returns the value `false`. For an empty config file, we instead want to return an empty hash (`{}`).

## Is there anything you'd like reviewers to focus on?

## Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] I've updated a documentation
