### PR TITLE
Add config class name to missing required attributes message

### DIFF
--- a/lib/anyway/config.rb
+++ b/lib/anyway/config.rb
@@ -373,7 +373,7 @@ module Anyway # :nodoc:
         values[name].nil? || (values[name].is_a?(String) && values[name].empty?)
       end.then do |missing|
         next if missing.empty?
-        raise_validation_error "The following config parameters are missing or empty: #{missing.join(", ")}"
+        raise_validation_error "The following config parameters for `#{self.class.name}` are missing or empty: #{missing.join(", ")}"
       end
     end
 

--- a/lib/anyway/config.rb
+++ b/lib/anyway/config.rb
@@ -373,7 +373,7 @@ module Anyway # :nodoc:
         values[name].nil? || (values[name].is_a?(String) && values[name].empty?)
       end.then do |missing|
         next if missing.empty?
-        raise_validation_error "The following config parameters for `#{self.class.name}` are missing or empty: #{missing.join(", ")}"
+        raise_validation_error "The following config parameters for `#{self.class.name}(config_name: #{self.class.config_name})` are missing or empty: #{missing.join(", ")}"
       end
     end
 


### PR DESCRIPTION
## What is the purpose of this pull request?

When missing required attributes for a configuration class, showing only the attribute name and not the config name makes it hard to track down the problem and how to fix it, particularly in larger codebases with many config classes.

## What changes did you make? (overview)

So, I simply added the class name of the config class where the required attribute is missing.

## Is there anything you'd like reviewers to focus on?

## Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation

I used the GH web UI to make this change, so I don't have any changes for any other files, but I can add that later if needed.
