### PR TITLE
[77] Bugfix | Fix string typecasting

### DIFF
--- a/lib/anyway/auto_cast.rb
+++ b/lib/anyway/auto_cast.rb
@@ -4,8 +4,8 @@ module Anyway
   module AutoCast
     # Regexp to detect array values
     # Array value is a values that contains at least one comma
-    # and doesn't start/end with quote
-    ARRAY_RXP = /\A[^'"].*\s*,\s*.*[^'"]\z/
+    # and doesn't start/end with quote or curly braces
+    ARRAY_RXP = /\A[^'"{].*\s*,\s*.*[^'"}]\z/
 
     class << self
       def call(val)

--- a/spec/auto_cast_spec.rb
+++ b/spec/auto_cast_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 
 describe Anyway::AutoCast do
   it "serializes a string", :aggregate_failures do
+    expect(described_class.call("{\"baz\":\"fizz\",\"baz2\":\"fizz2\"}")).to be_a String
     expect(described_class.call("1,2, 3")).to eq [1, 2, 3]
 
     expect(described_class.call("t")).to eq true


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

## What is the purpose of this pull request?

Fixes #77 

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

## What changes did you make? (overview)

There was an issue with regex in [Anyway::Autocast](https://github.com/Lokideos/anyway_config/blob/4943ab69cafb8978ec3d82a0936ee7d1a7362130/lib/anyway/auto_cast.rb#L8) class, which typecasted `"{\"baz\":\"fizz\",\"baz2\":\"fizz2\"}"` string to an array.

## Is there anything you'd like reviewers to focus on?

No

## Checklist

- [x] I've added tests for this change
- [x] ~I've added a Changelog entry~
- [x] ~I've updated a documentation~
