### PR TITLE
Fix Ruby 3.1 shorthand hash syntax

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,4 +42,5 @@ jobs:
         bundle exec rake rbs:generate
     - name: Run Steep
       run: |
-        bundle exec rake steep
+        gem install steep
+        rake steep

--- a/anyway_config.gemspec
+++ b/anyway_config.gemspec
@@ -33,15 +33,14 @@ Gem::Specification.new do |s|
   # When gem is installed from source, we add `ruby-next` as a dependency
   # to auto-transpile source files during the first load
   if ENV["RELEASING_ANYWAY"].nil? && File.directory?(File.join(__dir__, ".git"))
-    s.add_runtime_dependency "ruby-next", ">= 0.11.0"
+    s.add_runtime_dependency "ruby-next", ">= 0.14.0"
   else
-    s.add_runtime_dependency "ruby-next-core", ">= 0.11.0"
+    s.add_runtime_dependency "ruby-next-core", ">= 0.14.0"
   end
 
   s.add_development_dependency "ammeter", "~> 1.1.3"
   s.add_development_dependency "bundler", ">= 1.15"
   s.add_development_dependency "rake", ">= 13.0"
   s.add_development_dependency "rspec", ">= 3.8"
-  s.add_development_dependency "ruby-next", ">= 0.8"
-  s.add_development_dependency "steep"
+  s.add_development_dependency "ruby-next", ">= 0.14.0"
 end

--- a/gemfiles/rubocop.gemfile
+++ b/gemfiles/rubocop.gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org" do
   gem "rubocop-md", "~> 1.0"
   gem "standard", "~> 1.0"
-  gem "ruby-next", ">= 0.12"
+  gem "ruby-next", ">= 0.14.0"
 end

--- a/lib/anyway/tracing.rb
+++ b/lib/anyway/tracing.rb
@@ -86,7 +86,7 @@ module Anyway
         if trace?
           value.transform_values(&:to_h).tap { _1.default_proc = nil }
         else
-          {value, source}
+          {value:, source:}
         end
       end
 


### PR DESCRIPTION
Ruby Next updated its shorthand hash syntax to one Ruby 3.1 is going to use.


**Waiting for v0.14.0 Ruby Next release**