### PR TITLE
Default environmental key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master
 
+- Add ability to set default key for environmental YAML files. ([@skryukov])
+
+Define a key for environmental yaml files to read default values from with `config.anyway_config.default_environmental_key = "default"`.
+This way Anyway Config will try to read settings under the `"default"` key and then merge environmental settings into them.
+
 ## 2.2.2 (2020-10-26)
 
 - Fixed regression introduced by the `#deep_merge!` refinement.
@@ -439,3 +444,4 @@ No we're dependency-free!
 [@jastkand]: https://github.com/jastkand
 [@envek]: https://github.com/Envek
 [@progapandist]: https://github.com/progapandist
+[@skryukov]: https://github.com/skryukov

--- a/README.md
+++ b/README.md
@@ -373,6 +373,26 @@ staging:
 port: 3002 # This value will not be loaded at all
 ```
 
+To provide default values you can use YAML anchors, but they do not deep-merge settings, so Anyway Config provides a way to define a special top-level key for default values like this:
+
+```ruby
+config.anyway_config.default_environmental_key = "default"
+```
+
+After that, Anyway Config will start reading settings under the `"default"` key and then merge environmental settings into them.
+
+```yml
+default:
+  server: # This values will be loaded in all environments by default
+    host: localhost
+    port: 3002
+
+staging:
+  server:
+    host: staging.example.com # This value will override the defaults when Rails.env.staging? is true
+    # port will be set to the value from the defaults — 3002
+```
+
 You can specify the lookup path for YAML files in one of the following ways:
 
 - By setting `config.anyway_config.default_config_path` to a target directory path:

--- a/lib/anyway/rails/settings.rb
+++ b/lib/anyway/rails/settings.rb
@@ -17,6 +17,9 @@ module Anyway
       attr_reader :autoload_static_config_path, :autoloader
       attr_accessor :known_environments
 
+      # Define a key for environmental yaml files to read default values from
+      attr_accessor :default_environmental_key
+
       if defined?(::Zeitwerk)
         def autoload_static_config_path=(val)
           raise "Cannot setup autoloader after application has been initialized" if ::Rails.application.initialized?
@@ -63,5 +66,7 @@ module Anyway
 
     self.default_config_path = ->(name) { ::Rails.root.join("config", "#{name}.yml") }
     self.known_environments = %w[test development production]
+    # Don't try read defaults when no key defined
+    self.default_environmental_key = nil
   end
 end

--- a/lib/anyway/tracing.rb
+++ b/lib/anyway/tracing.rb
@@ -86,7 +86,7 @@ module Anyway
         if trace?
           value.transform_values(&:to_h).tap { _1.default_proc = nil }
         else
-          {value, source}
+          {value:, source:}
         end
       end
 

--- a/spec/dummy/config/cool_only_default_environment.yml
+++ b/spec/dummy/config/cool_only_default_environment.yml
@@ -1,0 +1,5 @@
+defaults:
+  host: "test.host"
+  user:
+    name: "root"
+    password: <%= ENV['ANY_SECRET_PASSWORD'] || "root" %>

--- a/spec/dummy/config/cool_unmatched_default_environment.yml
+++ b/spec/dummy/config/cool_unmatched_default_environment.yml
@@ -1,0 +1,9 @@
+defaults:
+  host: "default.host"
+  user:
+    name: "root"
+
+production:
+  host: "test.host"
+  user:
+    password: <%= ENV['ANY_SECRET_PASSWORD'] || "root" %>


### PR DESCRIPTION
## What is the purpose of this pull request?

This PR adds an ability to set default key for environmental YAML files.

To provide default values we can use YAML anchors, but they do not deep-merge settings, so this PR provides a way to define a special top-level key for default values like this:

```ruby
config.anyway_config.default_environmental_key = "default"
```

After that, Anyway Config will start reading settings under the `"default"` key and then merge environmental settings into them.

```yml
default:
  server: # This values will be loaded in all environments by default
    host: localhost
    port: 3002
staging:
  server:
    host: staging.example.com # This value will override the defaults when Rails.env.staging? is true
    # port will be set to the value from the defaults — 3002
```

## Is there anything you'd like reviewers to focus on?

In this implementation, a file with only the default key is considered environmental:

```yml
default:
  server: # This values will be loaded in all environments by default
    host: localhost
    port: 3002
```

## Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation
