### PR TITLE
Add support for ruby 3.1

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0"]
+        ruby: ["2.7", "3.0", "3.1"]
         gemfile: [
           "gemfiles/rails6.gemfile",
           "gemfiles/railsmaster.gemfile"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 Define a key for environmental yaml files to read default values from with `config.anyway_config.default_environmental_key = "default"`.
 This way Anyway Config will try to read settings under the `"default"` key and then merge environmental settings into them.
 
+- Add support for ruby 3.1
+
 ## 2.2.2 (2020-10-26)
 
 - Fixed regression introduced by the `#deep_merge!` refinement.

--- a/lib/anyway/loaders/yaml.rb
+++ b/lib/anyway/loaders/yaml.rb
@@ -30,9 +30,9 @@ module Anyway
         # empty. When this occurs, we return an empty hash instead, to match
         # the interface when no config file is present.
         if defined?(ERB)
-          ::YAML.load(ERB.new(File.read(path)).result) || {} # rubocop:disable Security/YAMLLoad
+          ::YAML.load(ERB.new(File.read(path)).result, aliases: true) || {} # rubocop:disable Security/YAMLLoad
         else
-          ::YAML.load_file(path) || {}
+          ::YAML.load_file(path, aliases: true) || {}
         end
       end
 

--- a/spec/config/cool.yml
+++ b/spec/config/cool.yml
@@ -1,5 +1,8 @@
-host: "test.host"
-user:
+default_user: &default_user
   name: "root"
   password: "root"
+
+host: "test.host"
+user:
+  <<: *default_user
 port: <%= ENV['ANYWAY_COOL_PORT'] || 9292 %>

--- a/spec/generators/config_generator_spec.rb
+++ b/spec/generators/config_generator_spec.rb
@@ -44,7 +44,7 @@ describe Anyway::Generators::ConfigGenerator, :rails, type: :generator do
       it "is a valid YAML with env keys" do
         is_expected.to exist
 
-        data = ::YAML.load_file(subject)
+        data = ::YAML.load_file(subject, aliases: true)
         expect(data.keys).to match_array(
           %w[default development test production]
         )

--- a/spec/loaders/yaml_spec.rb
+++ b/spec/loaders/yaml_spec.rb
@@ -12,6 +12,10 @@ describe Anyway::Loaders::YAML do
   it "parses YAML" do
     expect(subject).to eq(
       {
+        "default_user" => {
+          "name" => "root",
+          "password" => "root"
+        },
         "host" => "test.host",
         "user" => {
           "name" => "root",
@@ -26,6 +30,10 @@ describe Anyway::Loaders::YAML do
     hide_const("ERB")
     expect(subject).to eq(
       {
+        "default_user" => {
+          "name" => "root",
+          "password" => "root"
+        },
         "host" => "test.host",
         "user" => {
           "name" => "root",
@@ -42,6 +50,10 @@ describe Anyway::Loaders::YAML do
     specify do
       expect(subject).to eq(
         {
+          "default_user" => {
+            "name" => "root",
+            "password" => "root"
+          },
           "host" => "local.host",
           "user" => {
             "name" => "root",


### PR DESCRIPTION
Ruby 3.1 comes with Psych 4 that calls safe_load by default and does not
support aliases by default.

<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

## What is the purpose of this pull request?

Add support for ruby 3.1

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

## What changes did you make? (overview)

- Add the `aliases: true` option to `YAML.load` calls

## Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] I've updated a documentation
