### PR TITLE
Added space to exception string

### DIFF
--- a/lib/anyway/config.rb
+++ b/lib/anyway/config.rb
@@ -273,7 +273,7 @@ module Anyway # :nodoc:
         # - SomeModule::Config => "some_module"
         # - SomeConfig => "some"
         unless name =~ /^(\w+)(::)?Config$/
-          raise "Couldn't infer config name, please, specify it explicitly" \
+          raise "Couldn't infer config name, please, specify it explicitly " \
             "via `config_name :my_config`"
         end
 


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

## What changes did you make? (overview)
Added space in exception which raises when config name not specifies.
