### PR TITLE
Adds Ruby 3.2 to the CI matrix.  Updates checkout action versions.

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -16,7 +16,7 @@ jobs:
   markdownlint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
@@ -27,7 +27,7 @@ jobs:
   rubocop:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
@@ -39,7 +39,7 @@ jobs:
   forspell:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install Hunspell
       run: |
         sudo apt-get install hunspell
@@ -58,7 +58,7 @@ jobs:
   lychee:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Link Checker
       id: lychee
       uses: lycheeverse/lychee-action@v1.5.1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
   rubocop:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
@@ -30,7 +30,7 @@ jobs:
       matrix:
         ruby: ["3.0"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/rspec-jruby.yml
+++ b/.github/workflows/rspec-jruby.yml
@@ -15,7 +15,7 @@ jobs:
       BUNDLE_GEMFILE: gemfiles/jruby.gemfile
       CI: true
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: jruby-9.2 # See https://github.com/jruby/jruby/issues/6859

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -24,6 +24,15 @@ jobs:
         ]
         rbs: ['false']
         include:
+        - ruby: "3.2"
+          gemfile: "Gemfile"
+          rbs: 'true'
+        - ruby: "3.2"
+          gemfile: "gemfiles/rails7.gemfile"
+          rbs: 'false'
+        - ruby: "3.2"
+          gemfile: "gemfiles/railsmaster.gemfile"
+          rbs: 'false'
         - ruby: "3.1"
           gemfile: "Gemfile"
           rbs: 'true'
@@ -43,7 +52,7 @@ jobs:
           gemfile: "gemfiles/rails6.gemfile"
           rbs: 'false'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}


### PR DESCRIPTION
## What is the purpose of this pull request?

Adds Ruby 3.2 to the CI matrix and updates some out-of-date actions that are generating versions

## What changes did you make? (overview)

Added entries in the `rspec.yml` file to test Ruby 3.2
Updated `checkout` action from `v2` to `v3` in all GitHub action files.

Runs green on my fork.

## Is there anything you'd like reviewers to focus on?

## Checklist

- [X] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation

Not sure if this requires a Changelog entry or documentation update.