### PR TITLE
#as_env which converts a config instance to the ENV-like hash

### DIFF
--- a/lib/anyway/config.rb
+++ b/lib/anyway/config.rb
@@ -27,6 +27,7 @@ module Anyway # :nodoc:
     RESERVED_NAMES = %i[
       config_name
       env_prefix
+      as_env
       values
       class
       clear
@@ -415,6 +416,10 @@ module Anyway # :nodoc:
       end
     end
 
+    def as_env
+      flatten_hash(to_h, env_prefix)
+    end
+
     private
 
     attr_reader :values, :__trace__
@@ -439,6 +444,20 @@ module Anyway # :nodoc:
 
     def raise_validation_error(msg)
       raise ValidationError, msg
+    end
+
+    def flatten_hash(hash, prefix, memo = {})
+      hash.each do |key, value|
+        prefix_with_key = "#{prefix}_#{key.to_s.upcase}"
+
+        if value.is_a?(Hash)
+          flatten_hash(value, "#{prefix_with_key}_", memo)
+        else
+          memo[prefix_with_key] = value.to_s
+        end
+      end
+
+      memo
     end
 
     def __type_caster__

--- a/sig/anyway_config.rbs
+++ b/sig/anyway_config.rbs
@@ -98,10 +98,12 @@ module Anyway
     def to_source_trace: -> Hash[String, untyped]
     def inspect: -> String
     def pretty_print: (untyped q) -> untyped
+    def as_env: -> Hash[String, String]
 
     private
     attr_reader values: Hash[untyped, untyped]
     def raise_validation_error: (String msg) -> void
+    def flatten_hash: (Hash[untyped, untyped], String, Hash[String, String]) -> Hash[String, String]
 
     class Error < StandardError
     end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -321,6 +321,16 @@ describe Anyway::Config, type: :config do
         end
       end
     end
+
+    describe "#as_env" do
+      it "returns ENV-like hash" do
+        expect(conf.as_env).to eq({"COOL_HOST" => "test.host",
+                                   "COOL_META__KOT" => "leta",
+                                   "COOL_PORT" => "8080",
+                                   "COOL_USER__NAME" => "secret man",
+                                   "COOL_USER__PASSWORD" => "root"})
+      end
+    end
   end
 
   context "without Rails", :norails do


### PR DESCRIPTION
<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

## What is the purpose of this pull request?

Make able to convert a config instance to the ENV-like hash.

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

## What changes did you make? (overview)

Added #as_env method which converts a config instance to the ENV-like hash.

## Is there anything you'd like reviewers to focus on?

## Checklist

- [x] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation
