### PR TITLE
Add loader_options, use to add ejson_namespace nil support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,11 @@ end
 See [#118](https://github.com/palkan/anyway_config/issues/118).
 
 - Added EJSON support. ([@inner-whisper])
+  - Add custom namespace support via `ejson_namespace` ([@bessey])
 
 - Add Doppler loader. ([@prog-supdex][]).
+- Add arbitrary custom loader options support via `loader_options` ([@bessey])
+
 
 ## 2.3.1 (2023-01-17)
 

--- a/README.md
+++ b/README.md
@@ -790,6 +790,18 @@ To debug any problems with loading configurations from `.ejson` files you can di
 ejson decrypt config/secrets.ejson
 ```
 
+You can customise the JSON namespace under which a loader searches for configuration via `loader_options`:
+
+```ruby
+class MyConfig < Anyway::Config
+  # To look under the key "foo" instead of the default key of "my"
+  loader_options ejson_namespace: "foo"
+
+  # Or to disable namespacing entirely, and instead search in the root object
+  loader_options ejson_namespace: false
+end
+```
+
 ### Custom loaders
 
 You can provide your own data loaders or change the existing ones using the Loaders API (which is very similar to Rack middleware builder):
@@ -811,6 +823,7 @@ def call(
   env_prefix:, # prefix for env vars if any
   config_path:, # path to YML config
   local: # true|false, whether to load local configuration
+  **options # custom options can be passed via Anyway::Config.loader_options example: "custom", option: "blah"
 )
   #=> must return Hash with configuration data
 end

--- a/lib/anyway/config.rb
+++ b/lib/anyway/config.rb
@@ -198,6 +198,15 @@ module Anyway # :nodoc:
         end
       end
 
+
+      def loader_options(val = nil)
+        return (@loader_options = val) unless val.nil?
+
+        return @loader_options if instance_variable_defined?(:@loader_options)
+
+        @loader_options = {}
+      end
+
       def new_empty_config() = {}
 
       def coerce_types(mapping)
@@ -342,7 +351,13 @@ module Anyway # :nodoc:
 
         config_path = resolve_config_path(config_name, env_prefix)
 
-        load_from_sources(base_config, name: config_name, env_prefix:, config_path:)
+        load_from_sources(
+          base_config,
+          name: config_name,
+          env_prefix:,
+          config_path:,
+          **self.class.loader_options
+        )
 
         if overrides
           Tracing.trace!(:load) { overrides }

--- a/lib/anyway/config.rb
+++ b/lib/anyway/config.rb
@@ -198,7 +198,6 @@ module Anyway # :nodoc:
         end
       end
 
-
       def loader_options(val = nil)
         return (@loader_options = val) unless val.nil?
 

--- a/lib/anyway/config.rb
+++ b/lib/anyway/config.rb
@@ -204,7 +204,11 @@ module Anyway # :nodoc:
 
         return @loader_options if instance_variable_defined?(:@loader_options)
 
-        @loader_options = {}
+        @loader_options = if superclass < Anyway::Config
+          superclass.loader_options
+        else
+          {}
+        end
       end
 
       def new_empty_config() = {}

--- a/lib/anyway/loaders/ejson.rb
+++ b/lib/anyway/loaders/ejson.rb
@@ -11,7 +11,7 @@ module Anyway
 
       self.bin_path = "ejson"
 
-      def call(name:, ejson_parser: Anyway::EJSONParser.new(EJSON.bin_path), **_options)
+      def call(name:, env_prefix:, ejson_parser: Anyway::EJSONParser.new(EJSON.bin_path), **_options)
         configs = []
 
         rel_config_paths.each do |rel_config_path|
@@ -23,7 +23,11 @@ module Anyway
 
           next unless secrets_hash
 
-          config_hash = secrets_hash[name]
+          config_hash = if env_prefix == ""
+              secrets_hash
+            else
+              secrets_hash[name]
+            end
 
           next unless config_hash.is_a?(Hash)
 

--- a/lib/anyway/loaders/ejson.rb
+++ b/lib/anyway/loaders/ejson.rb
@@ -23,10 +23,10 @@ module Anyway
 
           next unless secrets_hash
 
-          config_hash = if ejson_namespace.nil?
-            secrets_hash.except("_public_key")
-          else
+          config_hash = if ejson_namespace
             secrets_hash[ejson_namespace]
+          else
+            secrets_hash.except("_public_key")
           end
 
           next unless config_hash.is_a?(Hash)

--- a/lib/anyway/loaders/ejson.rb
+++ b/lib/anyway/loaders/ejson.rb
@@ -11,7 +11,7 @@ module Anyway
 
       self.bin_path = "ejson"
 
-      def call(name:, env_prefix:, ejson_parser: Anyway::EJSONParser.new(EJSON.bin_path), **_options)
+      def call(name:, ejson_namespace: name, ejson_parser: Anyway::EJSONParser.new(EJSON.bin_path), **_options)
         configs = []
 
         rel_config_paths.each do |rel_config_path|
@@ -23,11 +23,11 @@ module Anyway
 
           next unless secrets_hash
 
-          config_hash = if env_prefix == ""
-              secrets_hash
-            else
-              secrets_hash[name]
-            end
+          config_hash = if ejson_namespace.nil?
+            secrets_hash
+          else
+            secrets_hash[ejson_namespace]
+          end
 
           next unless config_hash.is_a?(Hash)
 

--- a/lib/anyway/loaders/ejson.rb
+++ b/lib/anyway/loaders/ejson.rb
@@ -24,7 +24,7 @@ module Anyway
           next unless secrets_hash
 
           config_hash = if ejson_namespace.nil?
-            secrets_hash
+            secrets_hash.except("_public_key")
           else
             secrets_hash[ejson_namespace]
           end

--- a/spec/loaders/ejson_spec.rb
+++ b/spec/loaders/ejson_spec.rb
@@ -81,6 +81,26 @@ describe Anyway::Loaders::EJSON do
       expect(subject).to eq(default_parsed_data)
     end
 
+    context "when ejson_namespace is set to nil" do
+      let(:ejson_parsed_result) do
+        {
+          "_public_key" => "any_public_key",
+          **default_parsed_data
+        }
+      end
+      let(:options) { {name: name, ejson_parser: ejson_parser, ejson_namespace: nil} }
+      let(:ejson_parser) do
+        parser = instance_double(Anyway::EJSONParser)
+        allow(parser).to receive(:call).with(config_path).and_return(ejson_parsed_result)
+        parser
+      end
+
+      it "parses default EJSON" do
+        # It also includes the public key, but we don't care about it
+        expect(subject).to include(default_parsed_data)
+      end
+    end
+
     context "when local is enabled" do
       let(:local) { true }
 

--- a/spec/loaders/ejson_spec.rb
+++ b/spec/loaders/ejson_spec.rb
@@ -84,9 +84,8 @@ describe Anyway::Loaders::EJSON do
     context "when ejson_namespace is set to false" do
       let(:ejson_parsed_result) do
         {
-          "_public_key" => "any_public_key",
-          **default_parsed_data
-        }
+          "_public_key" => "any_public_key"
+        }.merge(default_parsed_data)
       end
       let(:options) { {name: name, ejson_parser: ejson_parser, ejson_namespace: false} }
       let(:ejson_parser) do

--- a/spec/loaders/ejson_spec.rb
+++ b/spec/loaders/ejson_spec.rb
@@ -81,14 +81,14 @@ describe Anyway::Loaders::EJSON do
       expect(subject).to eq(default_parsed_data)
     end
 
-    context "when ejson_namespace is set to nil" do
+    context "when ejson_namespace is set to false" do
       let(:ejson_parsed_result) do
         {
           "_public_key" => "any_public_key",
           **default_parsed_data
         }
       end
-      let(:options) { {name: name, ejson_parser: ejson_parser, ejson_namespace: nil} }
+      let(:options) { {name: name, ejson_parser: ejson_parser, ejson_namespace: false} }
       let(:ejson_parser) do
         parser = instance_double(Anyway::EJSONParser)
         allow(parser).to receive(:call).with(config_path).and_return(ejson_parsed_result)

--- a/spec/loaders/ejson_spec.rb
+++ b/spec/loaders/ejson_spec.rb
@@ -96,8 +96,7 @@ describe Anyway::Loaders::EJSON do
       end
 
       it "parses default EJSON" do
-        # It also includes the public key, but we don't care about it
-        expect(subject).to include(default_parsed_data)
+        expect(subject).to eq(default_parsed_data)
       end
     end
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Ensures that EJSON, like the ENV and Doppler loaders, supports not utilising the namespaced configuration feature. 

Happy to follow up with tests and docs if you think this is reasonable!

## Is there anything you'd like reviewers to focus on?

~To keep the API surface small I have used the `env_prefix` keyword, even though its not really a prefix in this context (JSON nested keys). I figure consistency is preferable.~

## Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation
