### PR TITLE
Check Rails.env for current environment when ENV vars weren't set

### DIFF
--- a/lib/anyway/rails/settings.rb
+++ b/lib/anyway/rails/settings.rb
@@ -76,6 +76,7 @@ module Anyway
 
     self.default_config_path = ->(name) { ::Rails.root.join("config", "#{name}.yml") }
     self.known_environments = %w[test development production]
+    self.use_local_files ||= ::Rails.env.development?
     # Don't try read defaults when no key defined
     self.default_environmental_key = nil
   end


### PR DESCRIPTION
## What is the purpose of this pull request?

During migrations without setting RAILS_ENV or RACK_ENV rails behaves like running in `development` environment but anyway_config doesn't reflect this

## What changes did you make? (overview)

Add safe checking `Rails.env`

## Is there anything you'd like reviewers to focus on?

## Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [ ] I've updated a documentation
