### PR TITLE
Detect postponed Rails loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Load Rails extensions even if Rails was loaded after Anyway Config. ([@palkan][])
+
 - Fix handling `config.credentials.content_path` provided as String. ([@palkan][])
 
 ## 2.4.2 (2023-06-07)

--- a/README.md
+++ b/README.md
@@ -548,6 +548,14 @@ Alternatively, you can call `rails g anyway:app_config name param1 param2 ...`.
 
 **NOTE:** The generated `ApplicationConfig` class uses a singleton pattern along with `delegate_missing_to` to re-use the same instance across the application. However, the delegation can lead to unexpected behaviour and break Anyway Config internals if you have attributes named as `Anyway::Config` class methods. See [#120](https://github.com/palkan/anyway_config/issues/120).
 
+### Loading Anyway Config before Rails
+
+Anyway Config activates Rails-specific features automatically on the gem load only if Rails has been already required (we check for the `Rails::VERSION` constant presence). However, in some cases you may want to use Anyway Config before Rails initialization (e.g., in `config/puma.rb` when starting a Puma web server).
+
+By default, Anyway Config sets up a hook (via TracePoint API) and waits for Rails to be loaded to require the Rails extensions (`require "anyway/rails"`). In case you load Rails after Anyway Config, you will see a warning telling you about that. Note that config classes loaded before Rails are not populated from Rails-specific data sources (e.g., credentials).
+
+You can disable the warning by setting `Anyway::Rails.disable_postponed_load_warning = true` in your application. Also, you can disable the _hook_ completely by calling `Anyway::Rails.tracer.disable`.
+
 ## Using with Ruby
 
 The default data loading mechanism for non-Rails applications is the following (ordered by priority from low to high):

--- a/lib/anyway/rails/autoload.rb
+++ b/lib/anyway/rails/autoload.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# This module is used to detect a Rails application and activate the corresponding plugins
+# when Anyway Config is loaded before Rails (e.g., in config/puma.rb).
+module Anyway
+  module Rails
+    class << self
+      attr_reader :tracer
+      attr_accessor :disable_postponed_load_warning
+
+      private
+
+      def tracepoint_class_callback(event)
+        # Ignore singletons
+        return if event.self.singleton_class?
+
+        # We wait till `rails` has been loaded, which is enough to add a railtie
+        # https://github.com/rails/rails/blob/main/railties/lib/rails.rb
+        return unless event.self.name == "Rails"
+
+        # We must check for methods defined in `rails.rb` to distinguish events
+        # happening when we open the `Rails` module in other files.
+        if defined?(::Rails.env)
+          tracer.disable
+
+          unless disable_postponed_load_warning
+            warn "Anyway Config was loaded before Rails. Activating Anyway Config Rails plugins now.\n" \
+                 "NOTE: Already loaded configs were provisioned without Rails-specific sources."
+          end
+
+          require "anyway/rails"
+        end
+      end
+    end
+
+    @tracer = TracePoint.new(:class, &method(:tracepoint_class_callback))
+    @tracer.enable
+  end
+end

--- a/lib/anyway_config.rb
+++ b/lib/anyway_config.rb
@@ -45,5 +45,10 @@ module Anyway # :nodoc:
   end
 end
 
-require "anyway/rails" if defined?(::Rails::VERSION)
+if defined?(::Rails::VERSION)
+  require "anyway/rails"
+else
+  require "anyway/rails/autoload"
+end
+
 require "anyway/testing" if ENV["RACK_ENV"] == "test" || ENV["RAILS_ENV"] == "test"

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -199,31 +199,6 @@ describe Anyway::Config, type: :config do
         end
       end
 
-      context "when config_name contains underscores" do
-        let(:conf) do
-          klass = CoolConfig.dup
-          klass.class_eval do
-            config_name :cool_thing
-          end
-          klass.new
-        end
-
-        context "when env_name is set" do
-          let(:conf) do
-            klass = CoolConfig.dup
-            klass.class_eval do
-              config_name :cool_thing
-              env_prefix :cool_thing
-            end
-            klass.new
-          end
-
-          it "doesn't print deprecation warning" do
-            expect { conf }.not_to print_warning
-          end
-        end
-      end
-
       context "with types" do
         let(:conf) do
           klass = Class.new(CoolConfig)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,43 +15,6 @@ WebMock.disable_net_connect!(allow_localhost: true)
 
 NORAILS = ENV["NORAILS"] == "1"
 
-if ENV["VERIFY_RESERVED"] == "1"
-  require "set"
-
-  called_methods = Set.new
-  lib_path = File.realpath(File.join(File.dirname(__FILE__), "..", "lib"))
-
-  TracePoint.new(:call) do |ev|
-    # already tracked
-    next if called_methods.include?(ev.method_id)
-    # the event could be triggered before we load Anyway::Config
-    next unless defined?(Anyway::Config)
-    # filter out methods called not on Config instances
-    next unless Anyway::Config === ev.self
-    # select only methods defined by the library, not user
-    next unless ev.defined_class == Anyway::Config || Anyway::Config.included_modules.include?(ev.defined_class)
-    # make sure the method is called from the library code, not tests
-    next unless ev.binding.eval("caller").any? { |path| path.start_with?(lib_path) }
-
-    called_methods << ev.method_id
-  end.enable
-
-  RSpec.configure do |config|
-    config.after(:suite) do
-      called_methods = called_methods.to_a.select { |mid| mid =~ Anyway::Config::PARAM_NAME }
-
-      if (called_methods - Anyway::Config::RESERVED_NAMES).empty?
-        next puts "\nAnyway::Config::RESERVED is OK"
-      end
-
-      raise "Anyway::Config::RESERVED is invalid.\n" \
-        "Expected to contain: #{called_methods.sort}.\n" \
-        "Contains: #{Anyway::Config::RESERVED_NAMES.sort}.\n" \
-        "Missing elements: #{(called_methods - Anyway::Config::RESERVED_NAMES).sort}"
-    end
-  end
-end
-
 begin
   if NORAILS
     ENV["RACK_ENV"] = "test"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,9 @@ begin
   else
     ENV["RAILS_ENV"] = "test"
 
+    # Load anyway_config before Rails to test that we can detect Rails app before it's loaded
+    require "anyway_config"
+
     require "ammeter"
 
     require File.expand_path("dummy/config/environment", __dir__)

--- a/spec/support/verify_reserved.rb
+++ b/spec/support/verify_reserved.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+return unless ENV["VERIFY_RESERVED"] == "1"
+
+require "set"
+
+called_methods = Set.new
+lib_path = File.realpath(File.join(File.dirname(__FILE__), "..", "..", "lib"))
+
+TracePoint.new(:call) do |ev|
+  # already tracked
+  next if called_methods.include?(ev.method_id)
+  # the event could be triggered before we load Anyway::Config
+  next unless defined?(Anyway::Config)
+  # filter out methods called not on Config instances
+  next unless Anyway::Config === ev.self
+  # select only methods defined by the library, not user
+  next unless ev.defined_class == Anyway::Config || Anyway::Config.included_modules.include?(ev.defined_class)
+  # make sure the method is called from the library code, not tests
+  next unless ev.binding.eval("caller").any? { |path| path.start_with?(lib_path) }
+
+  called_methods << ev.method_id
+end.enable
+
+RSpec.configure do |config|
+  config.after(:suite) do
+    called_methods = called_methods.to_a.select { |mid| mid =~ Anyway::Config::PARAM_NAME }
+
+    if (called_methods - Anyway::Config::RESERVED_NAMES).empty?
+      next puts "\nAnyway::Config::RESERVED is OK"
+    end
+
+    raise "Anyway::Config::RESERVED is invalid.\n" \
+      "Expected to contain: #{called_methods.sort}.\n" \
+      "Contains: #{Anyway::Config::RESERVED_NAMES.sort}.\n" \
+      "Missing elements: #{(called_methods - Anyway::Config::RESERVED_NAMES).sort}"
+  end
+end


### PR DESCRIPTION
## What is the purpose of this pull request?

Make it possible to load Rails extensions even if `anyway_config` was loaded before Rails.

A use case in mind is using [Yabeda](https://github.com/yabeda-rb) (which uses Anyway Config) and its [Puma plugin](https://github.com/yabeda-rb/yabeda-puma-plugin) that is loaded from `config/puma.rb`.

## What changes did you make? (overview)

- Added `anyway/rails/autoload` module with the functionality for spying constants definitions (via TracePoint)

## Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [x] I've updated a documentation
