### PR TITLE
docs: clarify type coercion rules in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,14 +614,14 @@ Environmental variables for your config should start with your config name, uppe
 
 For example, if your config name is "mycoolgem", then the env var "MYCOOLGEM_PASSWORD" is used as `config.password`.
 
-By default, environment variables are automatically type cast\*:
+By default, environment variables are automatically type cast (rules are case-insensitive):
 
-- `"True"`, `"t"` and `"yes"` to `true`;
-- `"False"`, `"f"` and `"no"` to `false`;
+- `"true"`, `"t"`, `"yes"` and `"y"` to `true`;
+- `"false"`, `"f"`, `"no"` and `"n"` to `false`;
 - `"nil"` and `"null"` to `nil` (do you really need it?);
 - `"123"` to 123 and `"3.14"` to 3.14.
 
-\* See below for coercion customization.
+Type coercion can be [customized or disabled](#type-coercion).
 
 *Anyway Config* supports nested (_hashed_) env variables—just separate keys with double-underscore.
 

--- a/README.md
+++ b/README.md
@@ -619,7 +619,7 @@ By default, environment variables are automatically type cast (rules are case-in
 - `"true"`, `"t"`, `"yes"` and `"y"` to `true`;
 - `"false"`, `"f"`, `"no"` and `"n"` to `false`;
 - `"nil"` and `"null"` to `nil` (do you really need it?);
-- `"123"` to 123 and `"3.14"` to 3.14.
+- `"123"` to `123` and `"3.14"` to `3.14`.
 
 Type coercion can be [customized or disabled](#type-coercion).
 


### PR DESCRIPTION
## What is the purpose of this pull request?

Small documentation change in `README.md`.

I was looking up the rules for type autocasting, and it was unclear to me if the list `"True", "t" and "yes"` with a capital `T` meant that the value `True` had to use this exact case.

Looking at the code:

https://github.com/palkan/anyway_config/blob/d54f2caf2a9efb0ec4e9a7b095a2e48dcf908ba0/lib/anyway/auto_cast.rb#L19-L24

It looks like values are matched case-insensitively, so both `"True"` and `"true"` would work. And it looks like the value `"y"` is matched as `true`, which wasn't documented.

## What changes did you make? (overview)

1. Add missing values: make sure that the values `"y"` (coerced to `true`) and `"n"` (coerced to `false`) are listed.
2. Try to clarify case-insensitivity: list all values in lower-case (instead of a mix of lowercase and title case), and add a note that matching is case-insensitive.

## Is there anything you'd like reviewers to focus on?

Feel free to edit any of my changes. I'm not 100% happy with the way the case-sensitivity note reads, but I figured it might be better to have this note rather than not have that information.

## Checklist

- [ ] I've added tests for this change
- [ ] I've added a Changelog entry
- [x] I've updated a documentation
