### PR TITLE
fix: processing arrays for required except

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
 - Fix handling relative vs. absolute paths in `autoload_static_configs_path=`. ([@palkan][])
+- Fix support for array values in `except` option for required attributes. ([@dominikb][])
 
 ## 2.6.4 (2024-04-30)
 

--- a/lib/anyway/settings.rb
+++ b/lib/anyway/settings.rb
@@ -86,7 +86,7 @@ module Anyway
 
         if env.is_a?(::Hash)
           envs = env[:except]
-          excluded_envs = [envs].flat_map(&:to_s)
+          excluded_envs = [*envs].flat_map(&:to_s)
           excluded_envs.none?(current_environment)
         elsif env.is_a?(::Array)
           env.flat_map(&:to_s).include?(current_environment)

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -896,6 +896,16 @@ describe Anyway::Config, type: :config do
         end
       end
 
+      context "when current env matches one of env options under except array" do
+        before { allow(Anyway::Settings).to receive(:current_environment).and_return("local") }
+
+        let(:missed_keys) { [:sentry_api_key] }
+
+        it "not raises ValidationError" do
+          expect { demo_config.new }.to_not raise_error
+        end
+      end
+
       context "when env value under except key mismatched" do
         before { allow(Anyway::Settings).to receive(:current_environment).and_return("demo") }
 


### PR DESCRIPTION
## What is the purpose of this pull request?

The documented feature of allowing arrays for the `env: { except: }` option is broken.

### Reproducible example

```ruby
require 'bundler/inline'

gemfile(true) do
  source 'https://rubygems.org'

  gem 'anyway_config'
end

class MyConfig < Anyway::Config
  attr_config :user

  required :user, env: { except: [ 'test' ] }
end

Anyway::Settings.current_environment = 'test'

puts "Environment: #{Anyway::Settings.current_environment}"
[
  "Anyway::Settings.matching_env?('test')           # (true expected) ",
  "Anyway::Settings.matching_env?({except: 'test'}) # (false expected)",
  "Anyway::Settings.matching_env?(except: ['test']) # (false expected)",
].each { |example| puts("#{example} => #{eval(example)}")}

begin
  MyConfig.new
rescue StandardError => e
  puts e
end
```

#### Output

```txt
Fetching gem metadata from https://rubygems.org/...........
Resolving dependencies...
Environment: test
Anyway::Settings.matching_env?('test')           # (true expected)  => true
Anyway::Settings.matching_env?({except: 'test'}) # (false expected) => false
Anyway::Settings.matching_env?(except: ['test']) # (false expected) => true
The following config parameters for `MyConfig(config_name: my)` are missing or empty: user
```

## What changes did you make? (overview)

## Is there anything you'd like reviewers to focus on?

## Checklist

- [x] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] I've updated a documentation
