### PR TITLE
fix: NameError caused by undefined secrets instance variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- Address NameError: instance variable @secrets not defined issue ([@fbuys][])
+
 ## 2.7.1 (2025-02-24)
 
 - Suppress required validations when running Rails credentials commands. ([@palkan][])

--- a/lib/anyway/rails/loaders/secrets.rb
+++ b/lib/anyway/rails/loaders/secrets.rb
@@ -28,6 +28,11 @@ module Anyway
             # Reset secrets state if the app hasn't been initialized
             # See https://github.com/palkan/anyway_config/issues/14
             next if ::Rails.application.initialized?
+
+            # Address unable to load application: NameError: instance variable @secrets
+            # not defined
+            next unless ::Rails.application.instance_variable_defined?(:@secrets)
+
             ::Rails.application.remove_instance_variable(:@secrets)
           end
         end


### PR DESCRIPTION

<!--
  First of all, thanks for contributing!

  If it's a typo fix or minor documentation update feel free to skip the rest of this template!
-->

## What is the purpose of this pull request?

To fix a bug found after upgrading a legacy application to Rails 8. The application makes use of [yabeda-rails](https://github.com/yabeda-rb/yabeda-rails).

Fixes: https://github.com/palkan/anyway_config/issues/158

<!--
  If it's a bug fix, then link it to the issue, for example:

  Fixes #xxx
-->

## What changes did you make? (overview)

Added a check to see if the `@secrets` instance variable exist before we attempt to remove it.

## Is there anything you'd like reviewers to focus on?

I did not add any tests since it looks like `secrets` tests were removed.

## Checklist

- [ ] I've added tests for this change
- [x] I've added a Changelog entry
- [ ] I've updated a documentation
