### PR TITLE
Fix "it" keyword issue

### DIFF
--- a/lib/anyway/auto_cast.rb
+++ b/lib/anyway/auto_cast.rb
@@ -13,9 +13,9 @@ module Anyway
 
         case val
         when Hash
-          val.transform_values { call(it) }
+          val.transform_values { |item| call(item) }
         when ARRAY_RXP
-          val.split(/\s*,\s*/).map { call(it) }
+          val.split(/\s*,\s*/).map { |item| call(item) }
         when /\A(true|t|yes|y)\z/i
           true
         when /\A(false|f|no|n)\z/i

--- a/lib/anyway/config.rb
+++ b/lib/anyway/config.rb
@@ -154,7 +154,7 @@ module Anyway # :nodoc:
         if block
           load_callbacks << BlockCallback.new(block)
         else
-          load_callbacks.push(*names.map { NamedCallback.new(it) })
+          load_callbacks.push(*names.map { |name| NamedCallback.new(name) })
         end
       end
 
@@ -380,7 +380,7 @@ module Anyway # :nodoc:
       trace&.keep_if { |key| self.class.config_attributes.include?(key.to_sym) }
 
       # Run on_load callbacks
-      self.class.load_callbacks.each { it.apply_to(self) }
+      self.class.load_callbacks.each { |call| call.apply_to(self) }
 
       # Set trace after we write all the values to
       # avoid changing the source to accessor

--- a/lib/anyway/tracing.rb
+++ b/lib/anyway/tracing.rb
@@ -29,7 +29,7 @@ module Anyway
       def record_value(val, *path, **opts)
         key = path.pop
         trace = if val.is_a?(Hash)
-          Trace.new.tap { it.merge_values(val, **opts) }
+          Trace.new.tap { |trace| trace.merge_values(val, **opts) }
         else
           Trace.new(:value, val, **opts)
         end
@@ -84,7 +84,7 @@ module Anyway
 
       def to_h
         if trace?
-          value.transform_values(&:to_h).tap { it.default_proc = nil }
+          value.transform_values(&:to_h).tap { |item| item.default_proc = nil }
         else
           {value:, source:}
         end

--- a/lib/anyway/type_casting.rb
+++ b/lib/anyway/type_casting.rb
@@ -34,7 +34,7 @@ module Anyway
 
       if array
         raw_arr = raw.is_a?(String) ? raw.split(/\s*,\s*/) : Array(raw)
-        raw_arr.map { caster.call(it) }
+        raw_arr.map { |item| caster.call(item) }
       else
         caster.call(raw)
       end


### PR DESCRIPTION
## What is the purpose of this pull request?

I got an error when using [imgproxy](https://github.com/imgproxy/imgproxy.rb) on ruby ​​3.3.5. He uses anyway_config.

```
 undefined local variable or method it' for class Anyway::Config (NameError)
 load_callbacks.push(*names.map { NamedCallback.new(it) })
```
The problem is that starting with version [3.3 release](https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/) the `it` keyword in blocks was deprecated.


> `it` calls without arguments in a block with no ordinary parameters are deprecated. it will be a reference to the first block parameter in Ruby 3.4. [[Feature #18980]](https://bugs.ruby-lang.org/issues/18980)

## What changes did you make?
Replaced implicit use of the first argument with explicit one.