### PR TITLE
Fix `Settings` method redefinition warnings

### DIFF
--- a/lib/anyway/rails/settings.rb
+++ b/lib/anyway/rails/settings.rb
@@ -65,10 +65,12 @@ module Anyway
         @autoload_via_zeitwerk = defined?(::Zeitwerk)
       end
 
+      alias_method :current_environment, :current_environment
       def current_environment
         @current_environment || ::Rails.env.to_s
       end
 
+      alias_method :app_root, :app_root
       def app_root
         ::Rails.root
       end


### PR DESCRIPTION
Both `Settings.singleton_class#{current_environment, app_root}` are defined in `anyway/settings.rb` just to be redefined in `anyway/rails/settings.rb`.

Iff `anyway/rails/settings.rb` is loaded, it's loaded after `anyway/settings.rb`, so the patch is safe.
